### PR TITLE
Specific month and day doc type aliases used when creating

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,24 @@ After installing the package, just complete the configuration steps below and yo
     "CreateDayFolders": false,          
     "OrderByDescending": true,          
     "FolderDocType": "dateFolder",      
-    "ItemDocTypes": [ "contentPage" ],
+    "MonthFolderDocType": "",      
+    "DayFolderDocType": "",      
+    "ItemDocTypes": [ "blogpost" ],
     "AllowedParentIds": [ 2222 ],
     "AllowedParentDocTypes": ["blog"]
 }
 ```
 
-- **ItemDocTypes** | The doctype alias to create datefolders for. (e.g. "contentPage") - comma separated values are allowed for multiple doctype aliases
-- **ItemDateProperty** | The property of the itemDocType to read the date from. (e.g. "startDate") (don't add this key if you just want to use the document's create date)
-- **DateFolderDocType** | The doctype to use for creating the year/month/day folders. (e.g "DateFolder")
+- **ItemDocTypes** | The doctype alias to create datefolders for. (e.g. "blogpost") - comma separated values are allowed for multiple doctype aliases
+- **ItemDateProperty** | The property of the itemDocType to read the date from. (e.g. "startDate") - don't add this key if you just want to use the document's create date
+- **FolderDocType** | The doctype alias to use for creating the year/month/day folders. (e.g "dateFolder")
+- **MonthFolderDocType** | (Optional) The doctype alias to use for the month folder, if not specified will default to FolderDocType.
+- **DayFolderDocType** | (Optional) The doctype alias to use for the day folder, if not specified will default to FolderDocType.
 - **CreateDayFolders** | Boolean indicating whether or not day folders should be created, if false only years and months are created.
 - **OrderByDecending** | Boolean indicating sort order for date folders (default: false)
 - **AllowedParentIds** | (Optional) The node id for the parent(s) to limit the creation of datefolders to. (e.g. 1234) - comma separated values are allowed for multiple note ids
 - **AllowedParentDocTypes** | (Optional) The doctype alias for the parent(s) to limit the creation of datefolders to. (e.g. "blog") - comma separated values are allowed for multiple doctype aliases
+
 
 ## Changelog
 Version 11.0.0

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -15,14 +15,18 @@ Add the following configuration to your appsettings.json file:
     "CreateDayFolders": false,          
     "OrderByDescending": true,          
     "FolderDocType": "dateFolder",      
-    "ItemDocTypes": [ "contentPage" ],
+    "MonthFolderDocType": "",      
+    "DayFolderDocType": "",      
+    "ItemDocTypes": [ "blogpost" ],
     "AllowedParentIds": [ 2222 ],
     "AllowedParentDocTypes": ["blog"]
 }
 
-ItemDocType | The doctype alias to create datefolders for. (e.g. "contentPage") - comma separated values are allowed for multiple doctype aliases
-ItemDateProperty | The property of the itemDocType to read the date from. (e.g. "startDate") (don't add this key if you just want to use the document's create date)
-DateFolderDocType | The doctype to use for creating the year/month/day folders. (e.g "DateFolder")
+ItemDocType | The doctype alias to create datefolders for. (e.g. "blogpost") - comma separated values are allowed for multiple doctype aliases
+ItemDateProperty | The property of the itemDocType to read the date from. (e.g. "startDate") - don't add this key if you just want to use the document's create date
+FolderDocType | The doctype alias to use for creating the year/month/day folders. (e.g "dateFolder")
+MonthFolderDocType | (Optional) The doctype alias to use for the month folder, if not specified will default to FolderDocType.
+DayFolderDocType | (Optional) The doctype alias to use for the day folder, if not specified will default to FolderDocType.
 CreateDayFolders | Boolean indicating whether or not day folders should be created, if false only years and months are created.
 OrderByDecending | Boolean indicating sort order for date folders (default: false)
 AllowedParentIds | (Optional) The node id for the parent(s) to limit the creation of datefolders to. (e.g. 1234) - comma separated values are allowed for multiple note ids

--- a/src/Infocaster.Umbraco.DateFolders/Models/DateFoldersConfigBase.cs
+++ b/src/Infocaster.Umbraco.DateFolders/Models/DateFoldersConfigBase.cs
@@ -8,6 +8,8 @@ namespace Infocaster.Umbraco.DateFolders.Models
         public List<int> AllowedParentIds { get; set; } = new List<int>();
         public List<string> AllowedParentDocTypes { get; set; } = new List<string>();
         public string FolderDocType { get; set; }
+        public string MonthFolderDocType { get; set; }
+        public string DayFolderDocType { get; set; }
         public bool OrderByDescending { get; set; } = true;
         public bool CreateDayFolders { get; set; } = false;
         public string ItemDateProperty { get; set; }


### PR DESCRIPTION
Hey @D-Inventor!

I am raising this as a draft PR in case you have any input on the approach I'm taking for issue https://github.com/Infocaster/Datefolders/issues/3.

I have got as far as updating the code for the creation of new items. My next step is to update the code for the saving of existing items, and then finally to check the two recycle bin related notification handlers.

This has been tested on a v11 site, both with the new feature (i.e. with `MonthFolderDocType` and `DayFolderDocType` options configured) and without (i.e. the way you had previously). 

Whilst I've been working on this I also did a bit of consolidating of the readme instructions:

- There were a couple of rogue 'DateFolderDocType' entries (should be 'FolderDocType')
- I changed the example `ItemDocType` alias to 'blogpost' as the `AllowedParentDocTypes` is set to 'blog'. I think blog posts are also a more likely use case than someone using it for a generically named doc type such as 'contentPage'

I checked Infocaster's contributing guidelines: there isn't a `contrib` branch on this repo so I assumed `v11/develop` was the one to branch from 🤞 